### PR TITLE
Allow EveryPolitician as the module name

### DIFF
--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -70,3 +70,6 @@ module Everypolitician
     end
   end
 end
+
+# Alternative constant name which is how it's usually capitalized in public copy.
+EveryPolitician = Everypolitician

--- a/test/everypolitician_test.rb
+++ b/test/everypolitician_test.rb
@@ -79,4 +79,8 @@ class EverypoliticianTest < Minitest::Test
         'everypolitician/everypolitician-data/master/countries.json'
     end
   end
+
+  def test_alternative_constant_name
+    assert_equal Everypolitician, EveryPolitician
+  end
 end


### PR DESCRIPTION
In the spirit of the principle of least surprise allow people to use `EveryPolitician` as well as `Everypolitician`.
