### PR TITLE
Allow pointing to a different countries.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ senate = australia.legislature('Senate')
 senate.popolo # data/Australia/Senate/ep-popolo-v1.0.json
 ```
 
+If you want to point at a different `countries.json`, e.g. a local path or a different url, you can set it like this:
+
+```ruby
+Everypolitician.countries_json = 'path/to/local/countries.json'
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -5,6 +5,15 @@ require 'open-uri'
 module Everypolitician
   class Error < StandardError; end
 
+  class << self
+    attr_writer :countries_json
+  end
+
+  def self.countries_json
+    @countries_json ||= 'https://raw.githubusercontent.com/' \
+      'everypolitician/everypolitician-data/master/countries.json'
+  end
+
   def self.country(slug)
     Country.find(slug)
   end
@@ -53,20 +62,17 @@ module Everypolitician
     include Enumerable
 
     def countries
-      @countries ||= JSON.parse(countries_json, symbolize_names: true)
+      @countries ||= JSON.parse(raw_json_string, symbolize_names: true)
     end
 
     def each(&block)
       countries.each(&block)
     end
 
-    def countries_json
-      @countries_json ||= open(countries_json_url).read
-    end
+    private
 
-    def countries_json_url
-      @url ||= 'https://raw.githubusercontent.com/' \
-        'everypolitician/everypolitician-data/master/countries.json'
+    def raw_json_string
+      @json ||= open(Everypolitician.countries_json).read
     end
   end
 end

--- a/test/everypolitician_test.rb
+++ b/test/everypolitician_test.rb
@@ -74,9 +74,14 @@ class EverypoliticianTest < Minitest::Test
 
   def test_retrieving_countries_json
     VCR.use_cassette('countries_json') do
-      countries_json = Everypolitician::CountriesJson.new
-      assert_equal countries_json.countries_json_url, 'https://raw.githubusercontent.com/' \
+      assert_equal Everypolitician.countries_json, 'https://raw.githubusercontent.com/' \
         'everypolitician/everypolitician-data/master/countries.json'
     end
+  end
+
+  def test_setting_countries_json_url
+    Everypolitician.countries_json = 'path/to/local/countries.json'
+    assert_equal 'path/to/local/countries.json', Everypolitician.countries_json
+    Everypolitician.countries_json = nil
   end
 end


### PR DESCRIPTION
This allows you to point to a `countries.json` at a different url or a local path.
