### PR TITLE
Add a from_sources_dir method for dir to country/legislature

### DIFF
--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -116,6 +116,11 @@ module Everypolitician
     def directory
       @directory = raw_data[:sources_directory].split('/')[1,2].join('/')
     end
+
+    def self.from_sources_dir(dir)
+      @index_by_sources ||= EveryPolitician.countries.map(&:legislatures).flatten.group_by(&:directory)
+      @index_by_sources[dir][0]
+    end
   end
 
   class LegislativePeriod

--- a/test/everypolitician_test.rb
+++ b/test/everypolitician_test.rb
@@ -59,6 +59,15 @@ class EverypoliticianTest < Minitest::Test
     end
   end
 
+  def test_sources_dir_convenience_method
+    VCR.use_cassette('countries_json') do
+      legislature = Everypolitician::Legislature.from_sources_dir('Australia/Senate')
+      assert_equal 'Australia', legislature.country.name
+      assert_equal 'AU', legislature.country.code
+      assert_equal 'Senate', legislature.name
+    end
+  end
+
   def test_raises_an_error_for_unknown_slugs
     VCR.use_cassette('countries_json') do
       assert_raises Everypolitician::Error do


### PR DESCRIPTION
This is required for everypolitician#452 so we can work out from an
everypolitician-data PR which countries and legislatures are affected.
