### PR TITLE
Pin down versions of development dependencies

### DIFF
--- a/everypolitician.gemspec
+++ b/everypolitician.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'minitest'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'vcr'
-  spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'minitest', '~> 5.9.0'
+  spec.add_development_dependency 'pry', '~> 0.10.4'
+  spec.add_development_dependency 'vcr', '~> 3.0.3'
+  spec.add_development_dependency 'webmock', '~> 2.0.3'
 end


### PR DESCRIPTION
This change was prompted by the tests failing when using VCR 3.0.1 with
Webmock 2.0.2, because support for Webmock 2+ wasn't added until VCR
3.0.2. By being explicit about the versions of the development
dependencies we avoid wasting time trying to figure out why tests pass
on one machine but not another.

I've used the `~>` operator here so that we still get patch versions
that are higher than the one specified, but not lower.

Fixes #18 
