### PR TITLE
Define #to_s on Country, Legislature and LegislativePeriod

### DIFF
--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -74,9 +74,6 @@ module Everypolitician
       legislature
     end
 
-    def to_s
-      @name
-    end
   end
 
   class Legislature < Entity

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -124,9 +124,6 @@ module Everypolitician
       @index_by_sources[dir][0]
     end
 
-    def to_s
-      @name
-    end
   end
 
   class LegislativePeriod < Entity

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -79,8 +79,7 @@ module Everypolitician
     end
   end
 
-  class Legislature
-    attr_reader :name
+  class Legislature < Entity
     attr_reader :slug
     attr_reader :lastmod
     attr_reader :person_count
@@ -94,7 +93,7 @@ module Everypolitician
     end
 
     def initialize(legislature_data, country)
-      @name = legislature_data[:name]
+      super(legislature_data)
       @slug = legislature_data[:slug]
       @lastmod = legislature_data[:lastmod]
       @person_count = legislature_data[:person_count]

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -40,8 +40,7 @@ module Everypolitician
     [country, legislature]
   end
 
-  class Country
-    attr_reader :name
+  class Country < Entity
     attr_reader :code
     attr_reader :slug
     attr_reader :raw_data
@@ -54,7 +53,7 @@ module Everypolitician
     end
 
     def initialize(country_data)
-      @name = country_data[:name]
+      super(country_data)
       @code = country_data[:code]
       @slug = country_data[:slug]
       @raw_data = country_data

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -127,6 +127,10 @@ module Everypolitician
       @index_by_sources ||= EveryPolitician.countries.map(&:legislatures).flatten.group_by(&:directory)
       @index_by_sources[dir][0]
     end
+
+    def to_s
+      @name
+    end
   end
 
   class LegislativePeriod

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -132,17 +132,16 @@ module Everypolitician
     end
   end
 
-  class LegislativePeriod
+  class LegislativePeriod < Entity
     attr_reader :id
-    attr_reader :name
     attr_reader :slug
     attr_reader :legislature
     attr_reader :country
     attr_reader :raw_data
 
     def initialize(legislative_period_data, legislature, country)
+      super(legislative_period_data)
       @id = legislative_period_data[:id]
-      @name = legislative_period_data[:name]
       @slug = legislative_period_data[:slug]
       @legislature = legislature
       @country = country

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -73,6 +73,10 @@ module Everypolitician
       fail Error, "Unknown legislature: #{query}" if legislature.nil?
       legislature
     end
+
+    def to_s
+      @name
+    end
   end
 
   class Legislature

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -171,6 +171,10 @@ module Everypolitician
       raw_data[key]
     end
 
+    def to_s
+      @name
+    end
+
     private
 
     def parse_partial_date(date)

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -3,6 +3,7 @@ require 'json'
 require 'open-uri'
 require 'everypolitician/popolo'
 require 'csv'
+require 'everypolitician/entity'
 
 module Everypolitician
   class Error < StandardError; end

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -163,10 +163,6 @@ module Everypolitician
       raw_data[key]
     end
 
-    def to_s
-      @name
-    end
-
     private
 
     def parse_partial_date(date)

--- a/lib/everypolitician/entity.rb
+++ b/lib/everypolitician/entity.rb
@@ -1,0 +1,11 @@
+module Everypolitician
+
+  class Entity
+    attr_reader :name
+
+    def initialize(data)
+      @name = data[:name]
+    end
+  end
+
+end

--- a/lib/everypolitician/entity.rb
+++ b/lib/everypolitician/entity.rb
@@ -6,6 +6,10 @@ module Everypolitician
     def initialize(data)
       @name = data[:name]
     end
+
+    def to_s
+      @name
+    end
   end
 
 end

--- a/test/everypolitician/entity_test.rb
+++ b/test/everypolitician/entity_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class EverypoliticianTest < Minitest::Test
+
+  def test_entity_has_a_name
+    entity = Everypolitician::Entity.new({name: 'name'})
+    assert_equal 'name', entity.name
+  end
+
+end

--- a/test/everypolitician/entity_test.rb
+++ b/test/everypolitician/entity_test.rb
@@ -7,4 +7,9 @@ class EverypoliticianTest < Minitest::Test
     assert_equal 'name', entity.name
   end
 
+  def test_entity_uses_name_when_interpolated
+    entity = Everypolitician::Entity.new({name: 'name'})
+    assert_equal 'Fetching data for name', "Fetching data for #{entity}"
+  end
+
 end

--- a/test/everypolitician_test.rb
+++ b/test/everypolitician_test.rb
@@ -195,14 +195,4 @@ class EverypoliticianTest < Minitest::Test
     end
   end
 
-  def test_legislative_period_uses_name_when_interpolated
-    VCR.use_cassette('countries_json') do
-      au_first_legislative_period = Everypolitician
-        .country('Australia')
-        .legislature('Representatives')
-        .legislative_periods[1]
-      assert_equal 'Fetching data for 43rd Parliament', "Fetching data for #{au_first_legislative_period}"
-    end
-  end
-
 end

--- a/test/everypolitician_test.rb
+++ b/test/everypolitician_test.rb
@@ -195,13 +195,6 @@ class EverypoliticianTest < Minitest::Test
     end
   end
 
-  def test_country_uses_name_when_interpolated
-    VCR.use_cassette('countries_json') do
-      country = Everypolitician.country('UK')
-      assert_equal 'Fetching data for United Kingdom', "Fetching data for #{country}"
-    end
-  end
-
   def test_legislature_uses_name_when_interpolated
     VCR.use_cassette('countries_json') do
       legislature = Everypolitician.country('UK').legislature('Commons')

--- a/test/everypolitician_test.rb
+++ b/test/everypolitician_test.rb
@@ -195,13 +195,6 @@ class EverypoliticianTest < Minitest::Test
     end
   end
 
-  def test_legislature_uses_name_when_interpolated
-    VCR.use_cassette('countries_json') do
-      legislature = Everypolitician.country('UK').legislature('Commons')
-      assert_equal 'Fetching data for House of Commons', "Fetching data for #{legislature}"
-    end
-  end
-
   def test_legislative_period_uses_name_when_interpolated
     VCR.use_cassette('countries_json') do
       au_first_legislative_period = Everypolitician

--- a/test/everypolitician_test.rb
+++ b/test/everypolitician_test.rb
@@ -202,4 +202,11 @@ class EverypoliticianTest < Minitest::Test
     end
   end
 
+  def test_legislature_uses_name_when_interpolated
+    VCR.use_cassette('countries_json') do
+      legislature = Everypolitician.country('UK').legislature('Commons')
+      assert_equal 'Fetching data for House of Commons', "Fetching data for #{legislature}"
+    end
+  end
+
 end

--- a/test/everypolitician_test.rb
+++ b/test/everypolitician_test.rb
@@ -209,4 +209,14 @@ class EverypoliticianTest < Minitest::Test
     end
   end
 
+  def test_legislative_period_uses_name_when_interpolated
+    VCR.use_cassette('countries_json') do
+      au_first_legislative_period = Everypolitician
+        .country('Australia')
+        .legislature('Representatives')
+        .legislative_periods[1]
+      assert_equal 'Fetching data for 43rd Parliament', "Fetching data for #{au_first_legislative_period}"
+    end
+  end
+
 end

--- a/test/everypolitician_test.rb
+++ b/test/everypolitician_test.rb
@@ -195,4 +195,11 @@ class EverypoliticianTest < Minitest::Test
     end
   end
 
+  def test_country_uses_name_when_interpolated
+    VCR.use_cassette('countries_json') do
+      country = Everypolitician.country('UK')
+      assert_equal 'Fetching data for United Kingdom', "Fetching data for #{country}"
+    end
+  end
+
 end


### PR DESCRIPTION
This pull request allows countries, legislatures and legislative periods to be interpolated in a string and and have the name property of that object printed instead.

For that, a base class `Entity` was extracted that contains a `to_s` method.

Closes #5
