### PR TITLE
Turn `lastmod` into a Time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.9.0] - 2016-07-28
+
+### Added
+
+- The`Legislature#lastmod` attribute now returns a Time object instead of just
+a string with the time in seconds.
+
 ## [0.8.0] - 2016-07-26
 
 ### Added

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -92,7 +92,7 @@ module Everypolitician
     def initialize(legislature_data, country)
       @name = legislature_data[:name]
       @slug = legislature_data[:slug]
-      @lastmod = legislature_data[:lastmod]
+      @lastmod = to_UTC_time(legislature_data[:lastmod])
       @person_count = legislature_data[:person_count]
       @sha = legislature_data[:sha]
       @statement_count = legislature_data[:statement_count]
@@ -123,6 +123,13 @@ module Everypolitician
       @index_by_sources ||= EveryPolitician.countries.map(&:legislatures).flatten.group_by(&:directory)
       @index_by_sources[dir][0]
     end
+
+    private
+
+    def to_UTC_time(string_time)
+      Time.at(string_time.to_i).gmtime
+    end
+
   end
 
   class LegislativePeriod

--- a/lib/everypolitician/version.rb
+++ b/lib/everypolitician/version.rb
@@ -1,3 +1,3 @@
 module Everypolitician
-  VERSION = '0.8.0'
+  VERSION = '0.9.0'
 end

--- a/test/everypolitician_test.rb
+++ b/test/everypolitician_test.rb
@@ -195,4 +195,14 @@ class EverypoliticianTest < Minitest::Test
     end
   end
 
+  def test_lastmod_is_a_time
+    VCR.use_cassette('countries_json') do
+      australian_senate = Everypolitician.country(slug: 'Australia').legislature(slug: 'Senate')
+      assert_equal 2016, australian_senate.lastmod.year
+      assert_equal 7, australian_senate.lastmod.month
+      assert_equal 24, australian_senate.lastmod.day
+      assert_equal 17, australian_senate.lastmod.hour
+    end
+  end
+
 end


### PR DESCRIPTION
This pull request allows to return a Time object when accessing the `lastmod` field on a legislature.

Closes #10
