### PR TITLE
Find a country based on an EP.org URL slug

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,5 +51,7 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 8
 
-
+Performance/Casecmp:
+  Enabled: false
+    
 inherit_from: .rubocop_todo.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,18 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.11.0] - 2016-08-07
+
+### Added
+
+- Searches by slug for a Country or a Legislature are now case insensitive
+
 ## [0.10.0] - 2016-08-04
 
 ### Changed
 
-- The code now uses the `popolo_url` field from the data, so the url host has changed from `raw.githubusercontent.com` to `cdn.rawgit.com`.
+- The code now uses the `popolo_url` field from the data, so the url
+  host has changed from `raw.githubusercontent.com` to `cdn.rawgit.com`.
 
 ## [0.9.0] - 2016-07-28
 

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -47,7 +47,9 @@ module Everypolitician
 
     def self.find(query)
       query = { slug: query } if query.is_a?(String)
-      country = Everypolitician.countries.find { |c| query.all? { |k, v| c[k] == v } }
+      country = Everypolitician.countries.find do |c|
+        query.all? { |k, v| c[k].to_s.downcase == v.to_s.downcase }
+      end
       fail Error, "Couldn't find country for query: #{query}" if country.nil?
       new(country)
     end

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -71,7 +71,9 @@ module Everypolitician
 
     def legislature(query)
       query = { slug: query } if query.is_a?(String)
-      legislature = legislatures.find { |l| query.all? { |k, v| l.__send__(k) == v } }
+      legislature = legislatures.find do |l|
+        query.all? { |k, v| l.__send__(k).to_s.downcase == v.to_s.downcase }
+      end
       fail Error, "Unknown legislature: #{query}" if legislature.nil?
       legislature
     end

--- a/lib/everypolitician/version.rb
+++ b/lib/everypolitician/version.rb
@@ -1,3 +1,3 @@
 module Everypolitician
-  VERSION = '0.10.0'.freeze
+  VERSION = '0.11.0'.freeze
 end

--- a/test/everypolitician_test.rb
+++ b/test/everypolitician_test.rb
@@ -21,6 +21,13 @@ class EverypoliticianTest < Minitest::Test
     end
   end
 
+  def test_finds_country_by_hash_pair
+    VCR.use_cassette('countries_json') do
+      country = Everypolitician::Country.find(slug: 'Australia')
+      assert_equal 'Australia', country.name
+    end
+  end
+
   def test_find_country_is_case_insensitive
     VCR.use_cassette('countries_json') do
       country = Everypolitician::Country.find('new-zealand')

--- a/test/everypolitician_test.rb
+++ b/test/everypolitician_test.rb
@@ -44,6 +44,13 @@ class EverypoliticianTest < Minitest::Test
     end
   end
 
+  def test_find_legislature_is_case_insensitive
+    VCR.use_cassette('countries_json') do
+      legislature = Everypolitician::Legislature.find('UK', 'commons')
+      assert_equal 'House of Commons', legislature.name
+    end
+  end
+
   def test_country_convenience_method
     VCR.use_cassette('countries_json') do
       country = Everypolitician.country('Australia')

--- a/test/everypolitician_test.rb
+++ b/test/everypolitician_test.rb
@@ -21,6 +21,13 @@ class EverypoliticianTest < Minitest::Test
     end
   end
 
+  def test_find_country_is_case_insensitive
+    VCR.use_cassette('countries_json') do
+      country = Everypolitician::Country.find('new-zealand')
+      assert_equal 'New Zealand', country.name
+    end
+  end
+
   def test_legislature_find
     VCR.use_cassette('countries_json') do
       legislature = Everypolitician::Legislature.find('Australia', 'Senate')


### PR DESCRIPTION
This PR allows to make a search for a country or for a legislature using uppercase or lowercase queries.

Closes #17 
