### PR TITLE
Update VCR files

### DIFF
--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -13,7 +13,7 @@ module Everypolitician
   end
 
   def self.countries_json
-    @countries_json ||= 'https://raw.githubusercontent.com/' \
+    @countries_json ||= 'https://cdn.rawgit.com/' \
       'everypolitician/everypolitician-data/master/countries.json'
   end
 
@@ -105,7 +105,7 @@ module Everypolitician
     end
 
     def popolo_url
-      @popolo_url ||= 'https://raw.githubusercontent.com/everypolitician' \
+      @popolo_url ||= 'https://cdn.rawgit.com/everypolitician' \
         "/everypolitician-data/#{sha}/#{raw_data[:popolo]}"
     end
 
@@ -151,7 +151,7 @@ module Everypolitician
     end
 
     def csv_url
-      @csv_url ||= 'https://raw.githubusercontent.com/everypolitician' \
+      @csv_url ||= 'https://cdn.rawgit.com/everypolitician' \
         "/everypolitician-data/#{legislature.sha}/#{raw_data[:csv]}"
     end
 

--- a/test/everypolitician_test.rb
+++ b/test/everypolitician_test.rb
@@ -25,7 +25,7 @@ class EverypoliticianTest < Minitest::Test
     VCR.use_cassette('countries_json') do
       legislature = Everypolitician::Legislature.find('Australia', 'Senate')
       assert_equal 'Senate', legislature.name
-      assert_equal "https://raw.githubusercontent.com/everypolitician/everypolitician-data/#{@current_sha}/data/Australia/Senate/ep-popolo-v1.0.json", legislature.popolo_url
+      assert_equal "https://cdn.rawgit.com/everypolitician/everypolitician-data/#{@current_sha}/data/Australia/Senate/ep-popolo-v1.0.json", legislature.popolo_url
       assert legislature.legislative_periods.is_a?(Array)
     end
   end
@@ -43,7 +43,7 @@ class EverypoliticianTest < Minitest::Test
     VCR.use_cassette('countries_json') do
       legislature = Everypolitician.legislature('Australia', 'Senate')
       assert_equal 'Senate', legislature.name
-      assert_equal "https://raw.githubusercontent.com/everypolitician/everypolitician-data/#{@current_sha}/data/Australia/Senate/ep-popolo-v1.0.json", legislature.popolo_url
+      assert_equal "https://cdn.rawgit.com/everypolitician/everypolitician-data/#{@current_sha}/data/Australia/Senate/ep-popolo-v1.0.json", legislature.popolo_url
       assert legislature.legislative_periods.is_a?(Array)
     end
   end
@@ -55,7 +55,7 @@ class EverypoliticianTest < Minitest::Test
       assert_equal 'AU', country.code
       assert_equal 2, country.legislatures.size
       assert_equal 'Senate', legislature.name
-      assert_equal "https://raw.githubusercontent.com/everypolitician/everypolitician-data/#{@current_sha}/data/Australia/Senate/ep-popolo-v1.0.json", legislature.popolo_url
+      assert_equal "https://cdn.rawgit.com/everypolitician/everypolitician-data/#{@current_sha}/data/Australia/Senate/ep-popolo-v1.0.json", legislature.popolo_url
       assert_equal 'Australia/Senate', legislature.directory
       assert legislature.legislative_periods.is_a?(Array)
     end
@@ -85,7 +85,7 @@ class EverypoliticianTest < Minitest::Test
 
   def test_retrieving_countries_json
     VCR.use_cassette('countries_json') do
-      assert_equal Everypolitician.countries_json, 'https://raw.githubusercontent.com/' \
+      assert_equal Everypolitician.countries_json, 'https://cdn.rawgit.com/' \
         'everypolitician/everypolitician-data/master/countries.json'
     end
   end
@@ -146,7 +146,7 @@ class EverypoliticianTest < Minitest::Test
       assert_equal '44th Parliament', lp.name
       assert_equal Date.new(2013, 9, 7), lp.start_date
       assert_equal '44', lp.slug
-      assert_equal "https://raw.githubusercontent.com/everypolitician/everypolitician-data/#{@current_sha}/data/Australia/Senate/term-44.csv", lp.csv_url
+      assert_equal "https://cdn.rawgit.com/everypolitician/everypolitician-data/#{@current_sha}/data/Australia/Senate/term-44.csv", lp.csv_url
       assert_equal 'Senate', lp.legislature.name
       assert_equal 'Australia', lp.country.name
     end

--- a/test/fixtures/vcr_cassettes/countries_json.yml
+++ b/test/fixtures/vcr_cassettes/countries_json.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/countries.json
+    uri: https://cdn.rawgit.com/everypolitician/everypolitician-data/master/countries.json
     body:
       encoding: US-ASCII
       string: ''
@@ -18,52 +18,34 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Content-Security-Policy:
-      - default-src 'none'; style-src 'unsafe-inline'
-      Strict-Transport-Security:
-      - max-age=31536000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Xss-Protection:
-      - 1; mode=block
-      Etag:
-      - '"4bd527756680f45fd72dd715ebb33b7bc4eff21c"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Geo-Block-List:
-      - ''
-      X-Github-Request-Id:
-      - B91F121E:397A:30C824:579773B5
-      Content-Length:
-      - '40507'
-      Accept-Ranges:
-      - bytes
       Date:
-      - Tue, 26 Jul 2016 14:29:10 GMT
-      Via:
-      - 1.1 varnish
+      - Wed, 27 Jul 2016 13:55:25 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
-      X-Served-By:
-      - cache-lcy1123-LCY
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Robots-Tag:
+      - none
       Access-Control-Allow-Origin:
       - "*"
-      X-Fastly-Request-Id:
-      - b6738eebcea73aff30d8b30a4f5bb86d76d95964
+      Etag:
+      - W/"4bd527756680f45fd72dd715ebb33b7bc4eff21c"
+      Cache-Control:
+      - max-age=315360000
+      Vary:
+      - Accept-Encoding
       Expires:
-      - Tue, 26 Jul 2016 14:34:10 GMT
-      Source-Age:
-      - '0'
+      - Thu, 31 Dec 2037 23:55:55 GMT
+      Rawgit-Cache-Status:
+      - MISS
+      Server:
+      - NetDNA-cache/2.2
+      X-Cache:
+      - HIT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -9565,5 +9547,5 @@ http_interactions:
         CiAgICAgICAgICB9CiAgICAgICAgXSwKICAgICAgICAic3RhdGVtZW50X2Nv
         dW50IjogMzM0MQogICAgICB9CiAgICBdCiAgfQpd
     http_version: 
-  recorded_at: Tue, 26 Jul 2016 14:29:10 GMT
+  recorded_at: Wed, 27 Jul 2016 13:55:25 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/popolo.yml
+++ b/test/fixtures/vcr_cassettes/popolo.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/countries.json
+    uri: https://cdn.rawgit.com/everypolitician/everypolitician-data/master/countries.json
     body:
       encoding: US-ASCII
       string: ''
@@ -18,52 +18,34 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Content-Security-Policy:
-      - default-src 'none'; style-src 'unsafe-inline'
-      Strict-Transport-Security:
-      - max-age=31536000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Xss-Protection:
-      - 1; mode=block
-      Etag:
-      - '"4bd527756680f45fd72dd715ebb33b7bc4eff21c"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Geo-Block-List:
-      - ''
-      X-Github-Request-Id:
-      - B91F121E:397B:61A7F4:57977C61
-      Content-Length:
-      - '40507'
-      Accept-Ranges:
-      - bytes
       Date:
-      - Tue, 26 Jul 2016 15:06:09 GMT
-      Via:
-      - 1.1 varnish
+      - Wed, 27 Jul 2016 13:55:25 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
-      X-Served-By:
-      - cache-lcy1135-LCY
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Robots-Tag:
+      - none
       Access-Control-Allow-Origin:
       - "*"
-      X-Fastly-Request-Id:
-      - b14729a84969806379f44385687741623070b3a4
+      Etag:
+      - W/"4bd527756680f45fd72dd715ebb33b7bc4eff21c"
+      Cache-Control:
+      - max-age=315360000
+      Vary:
+      - Accept-Encoding
       Expires:
-      - Tue, 26 Jul 2016 15:11:09 GMT
-      Source-Age:
-      - '0'
+      - Thu, 31 Dec 2037 23:55:55 GMT
+      Rawgit-Cache-Status:
+      - MISS
+      Server:
+      - NetDNA-cache/2.2
+      X-Cache:
+      - HIT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -9565,10 +9547,10 @@ http_interactions:
         CiAgICAgICAgICB9CiAgICAgICAgXSwKICAgICAgICAic3RhdGVtZW50X2Nv
         dW50IjogMzM0MQogICAgICB9CiAgICBdCiAgfQpd
     http_version: 
-  recorded_at: Tue, 26 Jul 2016 15:06:10 GMT
+  recorded_at: Wed, 27 Jul 2016 13:55:25 GMT
 - request:
     method: get
-    uri: https://raw.githubusercontent.com/everypolitician/everypolitician-data/ea04acd/data/Australia/Senate/ep-popolo-v1.0.json
+    uri: https://cdn.rawgit.com/everypolitician/everypolitician-data/ea04acd/data/Australia/Senate/ep-popolo-v1.0.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9584,52 +9566,34 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Content-Security-Policy:
-      - default-src 'none'; style-src 'unsafe-inline'
-      Strict-Transport-Security:
-      - max-age=31536000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Xss-Protection:
-      - 1; mode=block
-      Etag:
-      - '"0d0aeb5c3d4c874967800d27cd4ed8d48a2a9ecf"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Geo-Block-List:
-      - ''
-      X-Github-Request-Id:
-      - B91F1217:4A20:2E151C:57977C61
-      Content-Length:
-      - '70190'
-      Accept-Ranges:
-      - bytes
       Date:
-      - Tue, 26 Jul 2016 15:06:10 GMT
-      Via:
-      - 1.1 varnish
+      - Wed, 27 Jul 2016 13:55:25 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
-      X-Served-By:
-      - cache-lcy1131-LCY
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Robots-Tag:
+      - none
       Access-Control-Allow-Origin:
       - "*"
-      X-Fastly-Request-Id:
-      - b9683bbd961f0f8b6762a9cfb3fb91668714da51
+      Etag:
+      - W/"0d0aeb5c3d4c874967800d27cd4ed8d48a2a9ecf"
+      Cache-Control:
+      - max-age=315360000
+      Vary:
+      - Accept-Encoding
       Expires:
-      - Tue, 26 Jul 2016 15:11:10 GMT
-      Source-Age:
-      - '1'
+      - Thu, 31 Dec 2037 23:55:55 GMT
+      Rawgit-Cache-Status:
+      - MISS
+      Server:
+      - NetDNA-cache/2.2
+      X-Cache:
+      - HIT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -30391,5 +30355,5 @@ http_interactions:
         ZWEvd2EiLAogICAgICAibmFtZSI6ICJXQSIsCiAgICAgICJ0eXBlIjogImNv
         bnN0aXR1ZW5jeSIKICAgIH0KICBdCn0=
     http_version: 
-  recorded_at: Tue, 26 Jul 2016 15:06:10 GMT
+  recorded_at: Wed, 27 Jul 2016 13:55:25 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/term-44-csv.yml
+++ b/test/fixtures/vcr_cassettes/term-44-csv.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/countries.json
+    uri: https://cdn.rawgit.com/everypolitician/everypolitician-data/master/countries.json
     body:
       encoding: US-ASCII
       string: ''
@@ -18,52 +18,34 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Content-Security-Policy:
-      - default-src 'none'; style-src 'unsafe-inline'
-      Strict-Transport-Security:
-      - max-age=31536000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Xss-Protection:
-      - 1; mode=block
-      Etag:
-      - '"4bd527756680f45fd72dd715ebb33b7bc4eff21c"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Geo-Block-List:
-      - ''
-      X-Github-Request-Id:
-      - B91F121E:397A:316936:579776B7
-      Content-Length:
-      - '40507'
-      Accept-Ranges:
-      - bytes
       Date:
-      - Tue, 26 Jul 2016 14:42:00 GMT
-      Via:
-      - 1.1 varnish
+      - Wed, 27 Jul 2016 13:55:26 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
-      X-Served-By:
-      - cache-lcy1128-LCY
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Robots-Tag:
+      - none
       Access-Control-Allow-Origin:
       - "*"
-      X-Fastly-Request-Id:
-      - 38e3ce08d863016465f808d1ff8dd8d9dd746433
+      Etag:
+      - W/"4bd527756680f45fd72dd715ebb33b7bc4eff21c"
+      Cache-Control:
+      - max-age=315360000
+      Vary:
+      - Accept-Encoding
       Expires:
-      - Tue, 26 Jul 2016 14:47:00 GMT
-      Source-Age:
-      - '0'
+      - Thu, 31 Dec 2037 23:55:55 GMT
+      Rawgit-Cache-Status:
+      - MISS
+      Server:
+      - NetDNA-cache/2.2
+      X-Cache:
+      - HIT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -9565,10 +9547,10 @@ http_interactions:
         CiAgICAgICAgICB9CiAgICAgICAgXSwKICAgICAgICAic3RhdGVtZW50X2Nv
         dW50IjogMzM0MQogICAgICB9CiAgICBdCiAgfQpd
     http_version: 
-  recorded_at: Tue, 26 Jul 2016 14:42:00 GMT
+  recorded_at: Wed, 27 Jul 2016 13:55:26 GMT
 - request:
     method: get
-    uri: https://raw.githubusercontent.com/everypolitician/everypolitician-data/ea04acd/data/Australia/Senate/term-44.csv
+    uri: https://cdn.rawgit.com/everypolitician/everypolitician-data/ea04acd/data/Australia/Senate/term-44.csv
     body:
       encoding: US-ASCII
       string: ''
@@ -9584,54 +9566,36 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Content-Security-Policy:
-      - default-src 'none'; style-src 'unsafe-inline'
-      Strict-Transport-Security:
-      - max-age=31536000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Xss-Protection:
-      - 1; mode=block
-      Etag:
-      - '"a0bcbc44e9ccb608d102c19a60720866deb27d59"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Geo-Block-List:
-      - ''
-      X-Github-Request-Id:
-      - B91F121B:102D:9DFBE:579776B8
-      Content-Length:
-      - '6610'
-      Accept-Ranges:
-      - bytes
       Date:
-      - Tue, 26 Jul 2016 14:42:00 GMT
-      Via:
-      - 1.1 varnish
+      - Wed, 27 Jul 2016 13:55:27 GMT
+      Content-Type:
+      - text/csv;charset=utf-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
-      X-Served-By:
-      - cache-lcy1125-LCY
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Robots-Tag:
+      - none
       Access-Control-Allow-Origin:
       - "*"
-      X-Fastly-Request-Id:
-      - 78dc08cd29941df64c2d51c398ffe9688771f116
+      Etag:
+      - '"a0bcbc44e9ccb608d102c19a60720866deb27d59"'
+      Cache-Control:
+      - max-age=315360000
+      Vary:
+      - Accept-Encoding
       Expires:
-      - Tue, 26 Jul 2016 14:47:00 GMT
-      Source-Age:
-      - '0'
+      - Thu, 31 Dec 2037 23:55:55 GMT
+      Rawgit-Cache-Status:
+      - HIT
+      Server:
+      - NetDNA-cache/2.2
+      X-Cache:
+      - HIT
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: |
         id,name,sort_name,email,twitter,facebook,group,group_id,area_id,area,chamber,term,start_date,end_date,image,gender
         b6b705a5-0355-4f1c-8951-273aed19156d,Alan Eggleston,"Eggleston, Alan",senator.eggleston@aph.gov.au,,,Liberal Party,liberal_party_of_australia,area/wa,WA,Senate,44,,2014-06-30,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/4L6/upload_ref_binary/4L6.JPG,male
@@ -9736,5 +9700,5 @@ http_interactions:
         72d03e5d-8c81-492e-8dfe-914f5889c62a,Ursula Stephens,"Stephens, Ursula",senator.stephens@aph.gov.au,,,Australian Labor Party,australian_labor_party,area/nsw,NSW,Senate,44,,2014-06-30,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/00AOS/upload_ref_binary/00AOS.jpg,female
         c43e89a3-e635-4eae-a186-1b0d4802e0fa,Zed Seselja,"Seselja, Zed",senator.seselja@aph.gov.au,zedseselja,zed.seselja,Liberal Party,liberal_party_of_australia,area/act,ACT,Senate,44,,,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/HZE/upload_ref_binary/HZE.jpg,male
     http_version: 
-  recorded_at: Tue, 26 Jul 2016 14:42:00 GMT
+  recorded_at: Wed, 27 Jul 2016 13:55:27 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
We were constructing the `popolo_url` manually, and pointing it to `https://raw.githubusercontent.com/'`. 

Now `countries.json`  [changed its format and contains a `popolo_url` field](https://github.com/everypolitician/everypolitician-data/pull/4007) which is pointing to `https://cdn.rawgit.com/`, so we bring our cassettes and tests back in line with current reality.

This PR is part of issue #11 and PR #24.

It's probably a good idea to merge this PR before #24.
