### PR TITLE
pin to Ruby 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in everypolitician.gemspec
 gemspec
+
+gem 'rubocop', '~> 0.42.0'


### PR DESCRIPTION
We've been seeing various problems with getting this running, so let's
revert to pinning at 2.0.0
