### PR TITLE
Fixes for index class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [0.13.0] - 2016-08-18
+
 ### Added
 
 - There is now an `Everypolitician::Index` class which can be instantiated with
@@ -121,3 +123,4 @@ a string with the time in seconds.
 [0.10.0]: https://github.com/everypolitician/everypolitician-ruby/compare/v0.9.0...v0.10.0
 [0.11.0]: https://github.com/everypolitician/everypolitician-ruby/compare/v0.10.0...v0.11.0
 [0.12.0]: https://github.com/everypolitician/everypolitician-ruby/compare/v0.11.0...v0.12.0
+[0.13.0]: https://github.com/everypolitician/everypolitician-ruby/compare/v0.12.0...v0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+- There is now an `Everypolitician::Index` class which can be instantiated with a custom SHA/ref, rather than having to globally set the ref via `Everypolitician.countries_json=`.
+  - You can access a country via the `Everypolitician::Index#country` method, which takes a (case-insensitive) slug for the country.
+  - You can get a list of all countries via the `Everypolitician::Index#countries` method.
+
 ## [0.12.0] - 2016-08-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- There is now an `Everypolitician::Index` class which can be instantiated with a custom SHA/ref, rather than having to globally set the ref via `Everypolitician.countries_json=`.
+- There is now an `Everypolitician::Index` class which can be instantiated with
+  a url pointing to a `countries.json` file. This replaces the need to globally
+  set a url via `Everypolitician.countries_json=`.
   - You can access a country via the `Everypolitician::Index#country` method, which takes a (case-insensitive) slug for the country.
   - You can get a list of all countries via the `Everypolitician::Index#countries` method.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ national_assembly = algeria.legislature('Majlis')
 
 # Iterate though all known countries
 Everypolitician::Index.new.countries do |country|
-  puts "#{country.name} has #{country.legislatures.size} legislatures"
+  puts "#{country.name} has #{country.legislatures.size} legislature(s)"
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,28 +25,29 @@ Use as shown below, passing the `:slug` of the country to the `country` method, 
 ```ruby
 require 'everypolitician'
 
-australia = Everypolitician.country('Australia')
+australia = Everypolitician::Index.new.country('Australia')
 australia.code # => "AU"
 senate = australia.legislature('Senate')
 senate.popolo # => #<Everypolitician::Popolo::JSON>
 
-united_kingdom = Everypolitician.country('UK')
+united_kingdom = Everypolitician::Index.new.country('UK')
 house_of_commons = united_kingdom.legislature('Commons')
 
-american_samoa = Everypolitician.country('American-Samoa')
+american_samoa = Everypolitician::Index.new.country('American-Samoa')
 house_of_representatives = american_samoa.legislature('House')
 
-united_arab_emirates = Everypolitician.country('United-Arab-Emirates')
+united_arab_emirates = Everypolitician::Index.new.country('United-Arab-Emirates')
 national_council = united_arab_emirates.legislature('Federal-National-Council')
 
-algeria = Everypolitician.country('Algeria')
+algeria = Everypolitician::Index.new.country('Algeria')
 national_assembly = algeria.legislature('Majlis')
 ```
 
-If you want to point at a different `countries.json`, e.g. a local path or a different url, you can set it like this:
+If you want to point at a different version of `countries.json` you can supply an
+`index_url` option to `Everypolitician::Index.new`.
 
 ```ruby
-Everypolitician.countries_json = 'path/to/local/countries.json'
+Everypolitician::Index.new(index_url: 'https://cdn.rawgit.com/everypolitician/everypolitician-data/080cb46/countries.json')
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ national_council = united_arab_emirates.legislature('Federal-National-Council')
 
 algeria = Everypolitician::Index.new.country('Algeria')
 national_assembly = algeria.legislature('Majlis')
+
+# Iterate though all known countries
+Everypolitician::Index.new.countries do |country|
+  puts "#{country.name} has #{country.legislatures.size} legislatures"
+end
 ```
 
 If you want to point at a different version of `countries.json` you can supply an

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -45,7 +45,7 @@ module Everypolitician
     end
 
     def country(slug)
-      country_index[slug]
+      country_index[slug.to_s.downcase]
     end
 
     def countries
@@ -59,7 +59,7 @@ module Everypolitician
     private
 
     def country_index
-      @country_index ||= Hash[countries.map { |c| [c.slug, c] }]
+      @country_index ||= Hash[countries.map { |c| [c.slug.downcase, c] }]
     end
 
     def countries_json

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -38,10 +38,13 @@ module Everypolitician
   end
 
   class Index
-    attr_reader :ref
+    DEFAULT_INDEX_URL = 'https://raw.githubusercontent.com/' \
+      'everypolitician/everypolitician-data/master/countries.json'.freeze
 
-    def initialize(ref = 'master')
-      @ref = ref
+    attr_reader :index_url
+
+    def initialize(index_url: DEFAULT_INDEX_URL)
+      @index_url = index_url
     end
 
     def country(slug)
@@ -50,7 +53,7 @@ module Everypolitician
 
     def countries
       @countries ||= begin
-        JSON.parse(open(countries_json).read, symbolize_names: true).map do |c|
+        JSON.parse(open(index_url).read, symbolize_names: true).map do |c|
           Country.new(c)
         end
       end
@@ -60,11 +63,6 @@ module Everypolitician
 
     def country_index
       @country_index ||= Hash[countries.map { |c| [c.slug.downcase, c] }]
-    end
-
-    def countries_json
-      @countries_json ||= 'https://raw.githubusercontent.com/' \
-        "everypolitician/everypolitician-data/#{ref}/countries.json"
     end
   end
 

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -48,18 +48,18 @@ module Everypolitician
       country_index[slug]
     end
 
-    private
-
-    def country_index
-      @country_index ||= Hash[countries.map { |c| [c.slug, c] }]
-    end
-
     def countries
       @countries ||= begin
         JSON.parse(open(countries_json).read, symbolize_names: true).map do |c|
           Country.new(c)
         end
       end
+    end
+
+    private
+
+    def country_index
+      @country_index ||= Hash[countries.map { |c| [c.slug, c] }]
     end
 
     def countries_json

--- a/lib/everypolitician/version.rb
+++ b/lib/everypolitician/version.rb
@@ -1,3 +1,3 @@
 module Everypolitician
-  VERSION = '0.12.0'.freeze
+  VERSION = '0.13.0'.freeze
 end

--- a/test/everypolitician_index_test.rb
+++ b/test/everypolitician_index_test.rb
@@ -16,4 +16,11 @@ class EverypoliticianIndexTest < Minitest::Test
       assert_equal 96_236, sweden.legislature('Riksdag').statement_count
     end
   end
+
+  def test_countries
+    VCR.use_cassette('countries_json') do
+      index = Everypolitician::Index.new
+      assert_equal 233, index.countries.size
+    end
+  end
 end

--- a/test/everypolitician_index_test.rb
+++ b/test/everypolitician_index_test.rb
@@ -17,6 +17,13 @@ class EverypoliticianIndexTest < Minitest::Test
     end
   end
 
+  def test_country_lowercase_slug
+    VCR.use_cassette('countries_json') do
+      index = Everypolitician::Index.new
+      refute_nil index.country('sweden')
+    end
+  end
+
   def test_countries
     VCR.use_cassette('countries_json') do
       index = Everypolitician::Index.new

--- a/test/everypolitician_index_test.rb
+++ b/test/everypolitician_index_test.rb
@@ -9,9 +9,11 @@ class EverypoliticianIndexTest < Minitest::Test
     end
   end
 
-  def test_country_with_sha
+  def test_country_with_index_url
     VCR.use_cassette('countries_json@bc95a4a') do
-      index = Everypolitician::Index.new('bc95a4a')
+      index_url = 'https://raw.githubusercontent.com/' \
+        'everypolitician/everypolitician-data/bc95a4a/countries.json'.freeze
+      index = Everypolitician::Index.new(index_url: index_url)
       sweden = index.country('Sweden')
       assert_equal 96_236, sweden.legislature('Riksdag').statement_count
     end


### PR DESCRIPTION
Couple of fixes to the `Everypolitician::Index` introduced in #42.
- Expose the `.countries` method
- Handle lowercase slugs
