### PR TITLE
Return `nil` for an empty date

### DIFF
--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -201,6 +201,7 @@ module Everypolitician
     private
 
     def parse_partial_date(date)
+      return if date.to_s.empty?
       Date.new(*date.split('-').map(&:to_i))
     end
   end

--- a/test/terms_test.rb
+++ b/test/terms_test.rb
@@ -47,6 +47,13 @@ class EverypoliticianTest < Minitest::Test
     end
   end
 
+  def test_missing_legislative_period_end_date
+    VCR.use_cassette('countries_json') do
+      lp = Everypolitician.country(slug: 'Australia').legislature(slug: 'Representatives').legislative_periods.first
+      assert_nil lp.end_date
+    end
+  end
+
   def test_partial_dates
     VCR.use_cassette('countries_json') do
       af = Everypolitician.country(slug: 'Albania').legislature(slug: 'Assembly')


### PR DESCRIPTION
Instead of blowing up when faced with an empty start_date or end_date, gracefully return `nil` instead.

Fixes #46 
