### PR TITLE
Rename lp to something more readable

### DIFF
--- a/test/terms_test.rb
+++ b/test/terms_test.rb
@@ -14,7 +14,8 @@ class EverypoliticianTest < Minitest::Test
       assert_equal '44th Parliament', term.name
       assert_equal Date.new(2013, 9, 7), term.start_date
       assert_equal '44', term.slug
-      assert %r{https://raw.githubusercontent.com/everypolitician/everypolitician-data/\w+?/data/Australia/Senate/term-44.csv}.match(term.csv_url)
+      assert_includes term.csv_url, 'https://raw.githubusercontent.com/everypolitician/everypolitician-data/'
+      assert_includes term.csv_url, '/data/Australia/Senate/term-44.csv'
       assert_equal 'Senate', term.legislature.name
       assert_equal 'Australia', term.country.name
     end

--- a/test/terms_test.rb
+++ b/test/terms_test.rb
@@ -9,22 +9,22 @@ class EverypoliticianTest < Minitest::Test
   def test_legislative_periods
     VCR.use_cassette('countries_json') do
       au_senate = Everypolitician.country(slug: 'Australia').legislature(slug: 'Senate')
-      lp = au_senate.legislative_periods.first
-      assert_equal 'term/44', lp.id
-      assert_equal '44th Parliament', lp.name
-      assert_equal Date.new(2013, 9, 7), lp.start_date
-      assert_equal '44', lp.slug
-      assert %r{https://raw.githubusercontent.com/everypolitician/everypolitician-data/\w+?/data/Australia/Senate/term-44.csv}.match(lp.csv_url)
-      assert_equal 'Senate', lp.legislature.name
-      assert_equal 'Australia', lp.country.name
+      term = au_senate.legislative_periods.first
+      assert_equal 'term/44', term.id
+      assert_equal '44th Parliament', term.name
+      assert_equal Date.new(2013, 9, 7), term.start_date
+      assert_equal '44', term.slug
+      assert %r{https://raw.githubusercontent.com/everypolitician/everypolitician-data/\w+?/data/Australia/Senate/term-44.csv}.match(term.csv_url)
+      assert_equal 'Senate', term.legislature.name
+      assert_equal 'Australia', term.country.name
     end
   end
 
   def test_legislative_period_csv
     VCR.use_cassette('term-44-csv') do
       au_senate = Everypolitician.country(slug: 'Australia').legislature(slug: 'Senate')
-      lp = au_senate.legislative_periods.first
-      csv = lp.csv
+      term = au_senate.legislative_periods.first
+      csv = term.csv
       assert_instance_of CSV::Table, csv
     end
   end
@@ -32,34 +32,34 @@ class EverypoliticianTest < Minitest::Test
   def test_legislative_period_square_brackets_expose_raw_data
     VCR.use_cassette('countries_json') do
       au_senate = Everypolitician.country(slug: 'Australia').legislature(slug: 'Senate')
-      lp = au_senate.legislative_periods.first
-      assert_equal 'term/44', lp[:id]
-      assert_equal '44th Parliament', lp[:name]
-      assert_equal '2013-09-07', lp[:start_date]
-      assert_equal 'data/Australia/Senate/term-44.csv', lp[:csv]
+      term = au_senate.legislative_periods.first
+      assert_equal 'term/44', term[:id]
+      assert_equal '44th Parliament', term[:name]
+      assert_equal '2013-09-07', term[:start_date]
+      assert_equal 'data/Australia/Senate/term-44.csv', term[:csv]
     end
   end
 
   def test_legislative_period_end_date
     VCR.use_cassette('countries_json') do
-      lp = Everypolitician.country(slug: 'Australia').legislature(slug: 'Representatives').legislative_periods[1]
-      assert_equal Date.new(2013, 9, 7), lp.end_date
+      term = Everypolitician.country(slug: 'Australia').legislature(slug: 'Representatives').legislative_periods[1]
+      assert_equal Date.new(2013, 9, 7), term.end_date
     end
   end
 
   def test_missing_legislative_period_end_date
     VCR.use_cassette('countries_json') do
-      lp = Everypolitician.country(slug: 'Australia').legislature(slug: 'Representatives').legislative_periods.first
-      assert_nil lp.end_date
+      term = Everypolitician.country(slug: 'Australia').legislature(slug: 'Representatives').legislative_periods.first
+      assert_nil term.end_date
     end
   end
 
   def test_partial_dates
     VCR.use_cassette('countries_json') do
       af = Everypolitician.country(slug: 'Albania').legislature(slug: 'Assembly')
-      lp = af.legislative_periods.last
-      assert_equal Date.new(2009), lp.start_date
-      assert_equal Date.new(2013), lp.end_date
+      term = af.legislative_periods.last
+      assert_equal Date.new(2009), term.start_date
+      assert_equal Date.new(2013), term.end_date
     end
   end
 end

--- a/test/terms_test.rb
+++ b/test/terms_test.rb
@@ -14,10 +14,17 @@ class EverypoliticianTest < Minitest::Test
       assert_equal '44th Parliament', term.name
       assert_equal Date.new(2013, 9, 7), term.start_date
       assert_equal '44', term.slug
-      assert_includes term.csv_url, 'https://raw.githubusercontent.com/everypolitician/everypolitician-data/'
-      assert_includes term.csv_url, '/data/Australia/Senate/term-44.csv'
       assert_equal 'Senate', term.legislature.name
       assert_equal 'Australia', term.country.name
+    end
+  end
+
+  def test_legislative_period_csv_url
+    VCR.use_cassette('countries_json') do
+      au_senate = Everypolitician.country(slug: 'Australia').legislature(slug: 'Senate')
+      term = au_senate.legislative_periods.first
+      assert_includes term.csv_url, 'https://raw.githubusercontent.com/everypolitician/everypolitician-data/'
+      assert_includes term.csv_url, '/data/Australia/Senate/term-44.csv'
     end
   end
 


### PR DESCRIPTION
Rename `lp` to `term` because it was confusing me a bit.
