### PR TITLE
Add csv_url method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,3 +149,4 @@ a string with the time in seconds.
 [0.13.0]: https://github.com/everypolitician/everypolitician-ruby/compare/v0.12.0...v0.13.0
 [0.14.0]: https://github.com/everypolitician/everypolitician-ruby/compare/v0.13.0...v0.14.0
 [0.15.0]: https://github.com/everypolitician/everypolitician-ruby/compare/v0.14.0...v0.15.0
+[0.16.0]: https://https://github.com/everypolitician/everypolitician-ruby/compare/v0.15.0...v0.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,21 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 
+
+## [0.16.0] - 2016-08-22
+
+### Added
+
+- Added `csv_url` to Legislature class. Returns full url of `names.csv` file. For example: `https://cdn.rawgit.com/everypolitician/everypolitician-data/ba976cf/data/UK/Commons/<names class="csv"></names>`
+
+
 ## [0.15.0] - 2016-08-23
 
 ### Fixed
 
 - Calling `start_date` or `end_date` on a Legislature which doesn’t have
   one now returns `nil` rather than raising an Exception.
+
 
 ## [0.14.0] - 2016-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added `csv_url` to Legislature class. Returns full url of `names.csv` file. For example: `https://cdn.rawgit.com/everypolitician/everypolitician-data/ba976cf/data/UK/Commons/<names class="csv"></names>`
-
+- Added `csv_url` to Legislature class. Returns full url of `names.csv` file. For example: `https://cdn.rawgit.com/everypolitician/everypolitician-data/ba976cf/data/UK/Commons/names.csv`
 
 ## [0.15.0] - 2016-08-23
 

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -159,8 +159,9 @@ module Everypolitician
       Time.at(lastmod_str.to_i).gmtime
     end
 
-    def names_path
-      @raw_data[:names]
+    def csv_url
+      @csv_url ||= 'https://cdn.rawgit.com/everypolitician' \
+        "/everypolitician-data/#{@sha}/#{raw_data[:names]}"
     end
   end
 

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -158,6 +158,10 @@ module Everypolitician
     def lastmod
       Time.at(lastmod_str.to_i).gmtime
     end
+
+    def names_path
+      @raw_data[:names]
+    end
   end
 
   class LegislativePeriod

--- a/lib/everypolitician/version.rb
+++ b/lib/everypolitician/version.rb
@@ -1,3 +1,3 @@
 module Everypolitician
-  VERSION = '0.15.0'.freeze
+  VERSION = '0.16.0'.freeze
 end

--- a/test/legislature_test.rb
+++ b/test/legislature_test.rb
@@ -68,4 +68,11 @@ class EverypoliticianTest < Minitest::Test
       assert_equal 'House of Commons', legislature[:name]
     end
   end
+
+  def test_names_method
+    VCR.use_cassette('countries_json') do
+      legislature = Everypolitician::Legislature.find('UK', 'commons')
+      assert_equal 'data/UK/Commons/names.csv', legislature.names_path
+    end
+  end
 end

--- a/test/legislature_test.rb
+++ b/test/legislature_test.rb
@@ -69,10 +69,13 @@ class EverypoliticianTest < Minitest::Test
     end
   end
 
-  def test_names_method
+  def test_csv_url_method
     VCR.use_cassette('countries_json') do
       legislature = Everypolitician::Legislature.find('UK', 'commons')
-      assert_equal 'data/UK/Commons/names.csv', legislature.names_path
+      base = 'https://cdn.rawgit.com/everypolitician/everypolitician-data/'
+      sha = legislature.sha
+      path = '/data/UK/Commons/names.csv'
+      assert_equal legislature.csv_url, "#{base}#{sha}#{path}"
     end
   end
 end


### PR DESCRIPTION
Adds method to expose the path to the legislature’s names.csv file as stored in the raw-data

Closes #49
