### PR TITLE
Require pry in the test helper

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require 'everypolitician'
 
 require 'minitest/autorun'
 require 'vcr'
+require 'pry'
 
 VCR.configure do |config|
   config.cassette_library_dir = 'test/fixtures/vcr_cassettes'


### PR DESCRIPTION
Instead of adding it to the class under test and then forgetting to remove it
it's better to add it to the helper so that it is always available.
