### PR TITLE
0.18.0 rename `Legislature.csv_url` as `Legislature.names_url`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [0.18.0] - 2016-08-25
+
+### Changed
+
+- The method to get the URL of the names file is now `Legislature.names_url`, 
+   not `Legislature.csv_url`
+
 ## [0.17.0] - 2016-08-23
 
 ### Changed
@@ -156,3 +163,4 @@ a string with the time in seconds.
 [0.15.0]: https://github.com/everypolitician/everypolitician-ruby/compare/v0.14.0...v0.15.0
 [0.16.0]: https://https://github.com/everypolitician/everypolitician-ruby/compare/v0.15.0...v0.16.0
 [0.17.0]: https://https://github.com/everypolitician/everypolitician-ruby/compare/v0.16.0...v0.17.0
+[0.18.0]: https://https://github.com/everypolitician/everypolitician-ruby/compare/v0.17.0...v0.18.0

--- a/lib/everypolitician.rb
+++ b/lib/everypolitician.rb
@@ -159,9 +159,9 @@ module Everypolitician
       Time.at(lastmod_str.to_i).gmtime
     end
 
-    def csv_url
-      @csv_url ||= 'https://cdn.rawgit.com/everypolitician' \
-        "/everypolitician-data/#{@sha}/#{raw_data[:names]}"
+    def names_url
+      'https://cdn.rawgit.com/everypolitician/everypolitician-data/%s/%s' %
+        [sha, raw_data[:names]]
     end
   end
 

--- a/lib/everypolitician/version.rb
+++ b/lib/everypolitician/version.rb
@@ -1,3 +1,3 @@
 module Everypolitician
-  VERSION = '0.17.0'.freeze
+  VERSION = '0.18.0'.freeze
 end

--- a/test/legislature_test.rb
+++ b/test/legislature_test.rb
@@ -75,7 +75,7 @@ class EverypoliticianTest < Minitest::Test
       base = 'https://cdn.rawgit.com/everypolitician/everypolitician-data/'
       sha = legislature.sha
       path = '/data/UK/Commons/names.csv'
-      assert_equal legislature.csv_url, "#{base}#{sha}#{path}"
+      assert_equal legislature.names_url, URI.join(base, sha + path).to_s
     end
   end
 end


### PR DESCRIPTION
0.16.0 [introduced](https://github.com/everypolitician/everypolitician-ruby/pull/51) a method to get the URL to the `names.csv` file for a Legislature. This was a Good Thing. Calling that method `csv_url`, however, wasn't. (Mea culpa for not noticing that change at review.)

`names.csv` is only one of many possible CSV files for a Legislature, and certainly not the one that deserves to be called _the_ CSV file for it. So rename that method to `names_url` instead, to 
- more accurately describe what you're getting back
- reduce confusion with the similar `LegislativePeriod.csv_url` method introduced in parallel [in 0.17](https://github.com/everypolitician/everypolitician-ruby/pull/54)
- not lay claim to such a broad concept.

ping @chrismytton @ondenman 
