### PR TITLE
add all_legislatures method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Added
+
+- Added `all_legislatures` to Index class. Returns an array of all the
+  Legislatures for all countries.
+
+## [0.19.0] - 2016-10-19
+
 ## Unreleased
 
 ## [0.18.0] - 2016-08-25

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ algeria = Everypolitician::Index.new.country('Algeria')
 national_assembly = algeria.legislature('Majlis')
 
 # Iterate though all known countries
-Everypolitician::Index.new.countries do |country|
+Everypolitician::Index.new.countries.each do |country|
   puts "#{country.name} has #{country.legislatures.size} legislature(s)"
 end
 ```

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ national_assembly = algeria.legislature('Majlis')
 Everypolitician::Index.new.countries.each do |country|
   puts "#{country.name} has #{country.legislatures.size} legislature(s)"
 end
+
+# Iterate through all known legislatures
+Everypolitician::Index.new.all_legislatures.each do |legislature|
+  puts "#{legislature.name} in #{legislature.country.name} has #{legislature.person_count} member(s)"
+end
 ```
 
 By default, the gem connects to EveryPolitician's data on GitHub over HTTPS and

--- a/lib/everypolitician/index.rb
+++ b/lib/everypolitician/index.rb
@@ -24,6 +24,10 @@ module Everypolitician
       end
     end
 
+    def all_legislatures
+      @all_legislatures ||= countries.flat_map(&:legislatures)
+    end
+
     private
 
     def country_index

--- a/lib/everypolitician/version.rb
+++ b/lib/everypolitician/version.rb
@@ -1,3 +1,3 @@
 module Everypolitician
-  VERSION = '0.18.0'.freeze
+  VERSION = '0.19.0'.freeze
 end

--- a/test/everypolitician_index_test.rb
+++ b/test/everypolitician_index_test.rb
@@ -32,4 +32,13 @@ class EverypoliticianIndexTest < Minitest::Test
       assert_equal 233, index.countries.size
     end
   end
+
+  def test_all_legislatures
+    VCR.use_cassette('countries_json') do
+      all = Everypolitician::Index.new.all_legislatures
+      assert_equal 243, all.count
+      assert_equal 'People\'s Assembly', all.first.name
+      assert_equal 'Lagting', all.last.name
+    end
+  end
 end


### PR DESCRIPTION
Adds an `all_legislatures` method to Index which returns an array of all the Legislatures.

Fixes #62 
