### PR TITLE
Enable warnings when running tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ require 'rake/testtask'
 require 'rubocop/rake_task'
 
 Rake::TestTask.new(:test) do |t|
+  t.warning = true
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']


### PR DESCRIPTION
This prints out any warnings when the tests are running. This should help catch bugs like the one we had where the test classes having the same name was causing an issue - https://github.com/everypolitician/everypolitician-ruby/pull/67/commits/ad5df017a18ab53318cc1d19bcc3435f776ba89e.
