### PR TITLE
Fix tests warnings by removing constant redefinition

### DIFF
--- a/test/everypolitician_test.rb
+++ b/test/everypolitician_test.rb
@@ -1,7 +1,5 @@
 require 'test_helper'
 
-CDN = 'https://cdn.rawgit.com'.freeze
-
 class EverypoliticianTest < Minitest::Test
   # Clear the countries.json cache before each run
   def setup

--- a/test/legislature_test.rb
+++ b/test/legislature_test.rb
@@ -1,7 +1,5 @@
 require 'test_helper'
 
-CDN = 'https://cdn.rawgit.com'.freeze
-
 class EverypoliticianLegislatureTest < Minitest::Test
   # Clear the countries.json cache before each run
   def setup

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,8 @@ require 'minitest/around/unit'
 require 'vcr'
 require 'pry'
 
+CDN = 'https://cdn.rawgit.com'.freeze
+
 VCR.configure do |config|
   config.cassette_library_dir = 'test/fixtures/vcr_cassettes'
   config.hook_into :webmock


### PR DESCRIPTION
Move the shared `CDN` constant into the test helper. This was causing
warnings about constant redefinition when running the tests.

Originally discussed in https://github.com/everypolitician/everypolitician-ruby/pull/69#pullrequestreview-6239083
