### PR TITLE
Test Ruby 2.3.1 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ rvm:
   - 2.0.0
   - 2.1.7
   - 2.2.3
+  - 2.3.1
 before_install: gem install bundler -v 1.10.6


### PR DESCRIPTION
This updates the Travis config to test the library using Ruby v2.3.1.
