### PR TITLE
Add Rubocop to the default rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: ruby
 cache: bundler
 sudo: false
-script:
-  - bundle exec rake test
-  - bundle exec rake rubocop
 rvm:
   - 2.0.0
   - 2.1.7

--- a/Rakefile
+++ b/Rakefile
@@ -11,4 +11,4 @@ end
 
 RuboCop::RakeTask.new
 
-task default: :test
+task default: %i(test rubocop)


### PR DESCRIPTION
This means that the rubocop checks are run at the same time as the tests when you run `bundle exec rake`. I've also removed the `script` section of the Travis config so the list of tasks to run isn't duplicated.
