### PR TITLE
Fix tests in legislature_test.rb

### DIFF
--- a/test/legislature_test.rb
+++ b/test/legislature_test.rb
@@ -9,9 +9,7 @@ class EverypoliticianLegislatureTest < Minitest::Test
   end
 
   def around
-    VCR.use_cassette('countries_json') do
-      yield
-    end
+    VCR.use_cassette('countries_json') { yield }
   end
 
   def test_legislature_find

--- a/test/legislature_test.rb
+++ b/test/legislature_test.rb
@@ -8,9 +8,9 @@ class EverypoliticianLegislatureTest < Minitest::Test
     Everypolitician.countries = nil
   end
 
-  def around(&block)
+  def around
     VCR.use_cassette('countries_json') do
-      block.call
+      yield
     end
   end
 

--- a/test/legislature_test.rb
+++ b/test/legislature_test.rb
@@ -73,7 +73,7 @@ class EverypoliticianLegislatureTest < Minitest::Test
   end
 
   def test_upper_house_with_missing_upper_house
-    bicameral = Everypolitician.country(code: 'UK')
+    bicameral = Everypolitician.country(code: 'GB')
     assert_equal nil, bicameral.upper_house
   end
 

--- a/test/legislature_test.rb
+++ b/test/legislature_test.rb
@@ -10,7 +10,7 @@ class EverypoliticianLegislatureTest < Minitest::Test
 
   def around(&block)
     VCR.use_cassette('countries_json') do
-      block
+      block.call
     end
   end
 


### PR DESCRIPTION
This fixes #75. As per @tmtmtmtm's suspicions, the problem was indeed the `around` block - the test block wasn't being called so the body of the test never executed.

This pull request also (that naughty word!) includes a fix to one of the tests that were failing and tidies up the style. I think bundling this up into the one PR is justified because it's all for the ultimate goal of this PR, which is to get `legislature_test.rb` working. But I'd be happy to be called out as wrong :smile: 