### PR TITLE
Remove unused Rubocop exception

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,10 +5,5 @@ inherit_from:
 AllCops:
   TargetRubyVersion: 2.3.3
 
-# We're OK with a class of EveryPolitician
-Style/ConstantName:
-  Exclude:
-    - 'lib/everypolitician.rb'
-
 Style/SafeNavigation:
   Enabled: false


### PR DESCRIPTION
This exception was causing a warning:

`.rubocop.yml: Style/ConstantName has the wrong namespace - should be Naming`

Since we don't use EveryPolitician (it's Everypolitician) there was no
point in having it (any more?) so it's safe to remove entirely.