### PR TITLE
Get the tests passing on the latest Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 2.1.7
-  - 2.2.3
-  - 2.3.1
-before_install: gem install bundler -v 1.10.6
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
+  - 2.6.0-preview2
+before_install: gem install bundler -v 1.16.6

--- a/everypolitician.gemspec
+++ b/everypolitician.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'everypolitician-popolo', '>= 0.8.0'
+  spec.add_dependency 'everypolitician-popolo', '>= 0.9.0'
   spec.add_dependency 'require_all'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.52.0'
   spec.add_development_dependency 'vcr', '~> 3.0.3'
-  spec.add_development_dependency 'webmock', '~> 2.0.3'
+  spec.add_development_dependency 'webmock', '~> 3.4.2'
 end


### PR DESCRIPTION
I was seeing some test failures when running on the latest Ruby with the most recent compatible gems.

1. require_all 2.0.0 has been released, and breaks the tests, so I've ~~specified that we need a version less than 2 in the gemspec~~ updated to the latest version of everypolitician-popolo, see https://github.com/everypolitician/everypolitician-ruby/pull/80#issuecomment-429258668.
2. Tests were failing for WebMock under Ruby 2.5, updating to the latest version fixed that.


I've also updated the Travis config to test on the latest Ruby versions.

Fixes https://github.com/everypolitician/everypolitician-ruby/issues/79